### PR TITLE
chore: update nuxt example

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
-
 export default defineNuxtConfig({
   // vue: {
   //   compilerOptions: {
@@ -8,6 +7,6 @@ export default defineNuxtConfig({
   //   }
   // }
   devtools: { enabled: true },
-
-  compatibilityDate: "2024-09-29"
-})
+  plugins: ["./plugins/vue-data-ui.client.ts"],
+  compatibilityDate: "2024-09-29",
+});

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 
 import { type VueUiXyConfig, type VueUiXyDatasetItem, VueUiXy } from "vue-data-ui";
-import "vue-data-ui/style.css";
 
 const config = ref<VueUiXyConfig>({
     chart: {

--- a/plugins/vue-data-ui.client.ts
+++ b/plugins/vue-data-ui.client.ts
@@ -1,5 +1,10 @@
-import { VueUiXy } from "vue-data-ui";
+import { VueUiXy, VueDataUi } from "vue-data-ui";
+import 'vue-data-ui/style.css'
 
 export default defineNuxtPlugin((nuxtApp) => {
     nuxtApp.vueApp.component("VueUiXy", VueUiXy);
+
+
+  // OR register the universal component if you plan to use it
+  nuxtApp.vueApp.component("VueDataUi", VueDataUi);
 })


### PR DESCRIPTION
While installing the `vue-data-ui` package for Nuxt 3 with this example, I felt like it missed the following changes to better understand the set-up within the project.

- Instead importing the `css` styles in every component where we use `vue-data-ui` components, we load it inside the plugin.
- Also, updated the `nuxt.config.ts` file to use the plugin file.